### PR TITLE
add settings: language_detection_mode, default_status, and delete_first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 - Changelog Formatting Improvements.
+- Added settings: language_detection_mode, default_status, and delete_first.
 
 ## [0.0.4] - 2016-10-06
 

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -25,14 +25,41 @@ form:
         0: Disabled
       validate:
         type: bool
-    default_language:
-      type: select
-      size: long
-      label: Default Language
-      help: Subscriber language used if detection fails for any reason.
-      default: 'en'
-      data-options@: '\Grav\Plugin\MailChimpPlugin::supportedLanguages'
     api_key:
       type: password
       label: API Key
       help: Your MailChimp API Key
+    language_detection_mode:
+      type: toggle
+      label: Language Detection Mode
+      help: "'Browser' tries to detect the browser's language, while 'Active' uses Grav's active language."
+      default: browser
+      options:
+        browser: Browser
+        active: Active
+    default_language:
+      type: select
+      size: long
+      label: Default Language
+      help: Subscriber language used if detection fails or the detected language is not supported by MailChimp.
+      default: 'en'
+      data-options@: '\Grav\Plugin\MailChimpPlugin::supportedLanguages'
+    default_status:
+      type: toggle
+      label: Default Status
+      help: "'Pending' sends a confirmation email. 'Subscribed' does not."
+      default: subscribed
+      options:
+        subscribed: Subscribed
+        pending: Pending
+    delete_first:
+      type: toggle
+      label: Delete Subscriber First
+      help: Whether to delete any existing subscriber with the email address we're about to add to the list before adding it (useful to re-send confirmation email).
+      highlight: 1
+      default: 0
+      options:
+        1: PLUGIN_ADMIN.YES
+        0: PLUGIN_ADMIN.NO
+      validate:
+        type: bool

--- a/mailchimp.yaml
+++ b/mailchimp.yaml
@@ -1,3 +1,6 @@
 enabled: true
-default_language: en
 api_key:
+language_detection_mode: browser
+default_language: en
+default_status: subscribed
+delete_first: false


### PR DESCRIPTION
`language_detection_mode` is useful if you have a multilingual site and you want to use the active language as the subscriber's language.

`default_status` is useful for double opt-in: http://stackoverflow.com/questions/31251271/realize-mailchimp-double-opt-in-with-api-3-0

`delete_first` allows to re-start the subscription process, which can be useful if you want users to receive something by email when they submit the form (which is achieved with `default_status: pending` and a custom confirmation email template). Submitting the form won't do anything if you're already subscribed, except if you delete the existing user from the list first. I realize this is a very specific use case, but I figured it could help somebody!