### PR TITLE
Adding trigger fields...

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,13 @@ form:
             label: My Custom Field
             placeholder: 'A Custom Field'
             type: text
+        -
+            name: news_letter
+            type: checkbox
+            label: 'Yes I would like to receive updated news and information'
     process:
         - mailchimp:
+            required_fields: [news_letter]
             lists: [1234567, abcdefg]
             field_mappings:
                 mailchimpMergeField: my_custom_field

--- a/mailchimp.php
+++ b/mailchimp.php
@@ -129,8 +129,41 @@ class MailChimpPlugin extends Plugin
     /**
      * @param Event $event
      */
+    protected function checkTriggers($event)
+    {
+
+        /* 
+            If the triggers are not even defined then just return true
+            so we can just process the MC submission
+        */
+
+        $params = $event['params'];
+        $form = $event['form'];
+
+        if ( isset($params['required_fields']) && !empty($params['required_fields']) ) {
+
+            $fields = (is_string($params['required_fields'])) ? [$params['required_fields']] : $params['required_fields'];
+
+            foreach ($fields as $field) {
+                $trigger_value = $form->value( $field );
+                if ( !$trigger_value ) { return false; }
+            }
+
+        }
+
+        return true;
+
+    }
+
+    /**
+     * @param Event $event
+     */
     protected function handleSubscribe(Event $event)
     {
+
+        // Ignore this processing if one of the required fields are empty
+        if ( !$this->checkTriggers($event) ) { return false; }
+
         $action = $event['action'];
         $form = $event['form'];
         $params = $event['params'];

--- a/mailchimp.php
+++ b/mailchimp.php
@@ -129,40 +129,13 @@ class MailChimpPlugin extends Plugin
     /**
      * @param Event $event
      */
-    protected function checkTriggers($event)
-    {
-
-        /* 
-            If the triggers are not even defined then just return true
-            so we can just process the MC submission
-        */
-
-        $params = $event['params'];
-        $form = $event['form'];
-
-        if ( isset($params['required_fields']) && !empty($params['required_fields']) ) {
-
-            $fields = (is_string($params['required_fields'])) ? [$params['required_fields']] : $params['required_fields'];
-
-            foreach ($fields as $field) {
-                $trigger_value = $form->value( $field );
-                if ( !$trigger_value ) { return false; }
-            }
-
-        }
-
-        return true;
-
-    }
-
-    /**
-     * @param Event $event
-     */
     protected function handleSubscribe(Event $event)
     {
 
         // Ignore this processing if one of the required fields are empty
-        if ( !$this->checkTriggers($event) ) { return false; }
+        if (!$this->shouldSubscribe($event)) {
+            return false;
+        }
 
         $action = $event['action'];
         $form = $event['form'];
@@ -196,6 +169,34 @@ class MailChimpPlugin extends Plugin
                 $this->grav['log']->error(sprintf('MailChimp error: %s', $mailChimp->getLastError()));
             }
         }, $listIDs);
+    }
+
+    /**
+     * @param Event $event
+     */
+    protected function shouldSubscribe($event)
+    {
+
+        /*
+            If the triggers are not even defined then just return true
+            so we can just process the MC submission
+        */
+
+        $params = $event['params'];
+        $form = $event['form'];
+
+        if (isset($params['required_fields']) && !empty($params['required_fields'])) {
+            $isStr  = (is_string($params['required_fields'])) ? true : false;
+            $fields = $isStr ? [$params['required_fields']] : $params['required_fields'];
+            foreach ($fields as $field) {
+                $trigger_value = $form->value($field);
+                if (!$trigger_value) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
     }
 
     /**


### PR DESCRIPTION
> Added the ability to only trigger MC submissions if specific forms fields were not blank, empty, or null. This adds flexability to your Grav forms. Use case would be optional newsletter signup in a form. Only submitting to MC if the user selects opt in.

A specific use case for this feature would be a contact form with a "Sign me up for news & special offers." The MC form only needs to be called when that checkbox is selected. 