### PR TITLE
Add default list ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- Default list ID can be specified in config.
+
 ## [0.0.5] - 2017-06-27
 
 ### Added

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -52,6 +52,10 @@ form:
       options:
         subscribed: MAILCHIMP_SETTINGS.DEFAULT_STATUS.OPTIONS.SUBSCRIBED
         pending: MAILCHIMP_SETTINGS.DEFAULT_STATUS.OPTIONS.PENDING
+    default_list_id:
+      type: text
+      label: MAILCHIMP_SETTINGS.DEFAULT_LIST_ID.LABEL
+      help: MAILCHIMP_SETTINGS.DEFAULT_LIST_ID.HELP
     delete_first:
       type: toggle
       label: MAILCHIMP_SETTINGS.DELETE_FIRST.LABEL

--- a/languages.yaml
+++ b/languages.yaml
@@ -20,6 +20,9 @@ en:
       OPTIONS:
         SUBSCRIBED: Subscribed
         PENDING: Pending
+    DEFAULT_LIST_ID:
+      LABEL: Default List ID
+      HELP: "List to use when none specified in form definition."
     DELETE_FIRST:
       LABEL: Delete Subscriber First
       HELP: Whether to delete any existing subscriber with the email address we're about to add to the list before adding it (useful to re-send confirmation email).

--- a/mailchimp.php
+++ b/mailchimp.php
@@ -142,7 +142,8 @@ class MailChimpPlugin extends Plugin
         $params = $event['params'];
 
         $mailChimp = $this->getAPIWrapper();
-        $listIDs = $params['lists'];
+        $listIDs = (array_key_exists('lists', $params)) ?
+            $params['lists'] : [$this->grav['config']->get('plugins.mailchimp.default_list_id')];
         $fieldMappings = (array_key_exists('field_mappings', $params)) ? $params['field_mappings'] : [];
         $language = $this->getLanguage();
 

--- a/mailchimp.yaml
+++ b/mailchimp.yaml
@@ -3,4 +3,5 @@ api_key:
 language_detection_mode: browser
 default_language: en
 default_status: subscribed
+default_list_id:
 delete_first: false


### PR DESCRIPTION
A default list ID can now be specified in the config and this will be
used if no lists are specified in the form definition.