### PR TITLE
Used put method instead of post to allow resubscribing existing users.

### DIFF
--- a/mailchimp.php
+++ b/mailchimp.php
@@ -163,7 +163,8 @@ class MailChimpPlugin extends Plugin
                 $mailChimp->delete("lists/{$listID}/members/" . md5(strtolower($emailAddress)));
             }
 
-            $mailChimp->post("lists/{$listID}/members", $data);
+            $subscriberHash = md5(strtolower($emailAddress));
+            $mailChimp->put("lists/{$listID}/members/{$subscriberHash}", $data);
 
             if (!$mailChimp->success()) {
                 $this->grav['log']->error(sprintf('MailChimp error: %s', $mailChimp->getLastError()));


### PR DESCRIPTION
Using the put method instead of post allows to subscribe users which have been unsubscribed. (https://developer.mailchimp.com/documentation/mailchimp/reference/lists/members/)
Currently resubscribing users fails silently.