### PR TITLE
Adjust blueprint to note v0.2.1 and fix some links

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -1,15 +1,14 @@
 name: MailChimp
-version: 0.2.0
+version: 0.2.1
 description: Add MailChimp subscribe form action support
 icon: plug
 author:
   name: Aaron Hipple
-  email: ahipple@gmail.com
+  email: aaron@hippl.es
 homepage: https://github.com/aaronhipple/grav-plugin-mailchimp
-demo: http://demo.yoursite.com
 keywords: grav, plugin, mailchimp
 bugs: https://github.com/aaronhipple/grav-plugin-mailchimp/issues
-docs: https://github.com/aaronhipple/grav-plugin-mailchimp/blob/develop/README.md
+docs: https://github.com/aaronhipple/grav-plugin-mailchimp/blob/master/README.md
 license: MIT
 
 form:


### PR DESCRIPTION
Attempting to fix some issues in how the plugin is presented in grav's plugin
repository. If this doesn't work, I'll need to follow up with them.

Separately, I'll file an issue to automate some of this release bookkeeping so
I don't keep forgetting to do this :(